### PR TITLE
Modified: brew install url

### DIFF
--- a/roles/brew/setup.sh
+++ b/roles/brew/setup.sh
@@ -21,7 +21,7 @@ config() {
 }
 
 install() {
-    /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
     config
 }
 


### PR DESCRIPTION
## 概要
brew の install 方法（URL）が変わったので、その修正。

- Ref. [HomebrewのインストーラーをRubyからBashに書き直しました！ - プログラムモグモグ](https://itchyny.hatenablog.com/entry/2020/03/03/100000)