### PR TITLE
Change version function

### DIFF
--- a/roles/ag/setup.sh
+++ b/roles/ag/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/ag)"
 }
 
 config() {

--- a/roles/alfred/setup.sh
+++ b/roles/alfred/setup.sh
@@ -13,8 +13,7 @@ is_installed() {
 }
 
 version() {
-    # echo "$(brew cask list $SETUP_CURRENT_ROLE_NAME --versions 2>/dev/null)" | cut -d' ' -f2
-    ls "/usr/local/Caskroom/$SETUP_CURRENT_ROLE_NAME" 2>/dev/null
+    ls /usr/local/Caskroom/alfred 2>/dev/null
 }
 
 config() {

--- a/roles/awscli/setup.sh
+++ b/roles/awscli/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/awscli)"
 }
 
 config() {

--- a/roles/bash/setup.sh
+++ b/roles/bash/setup.sh
@@ -13,8 +13,7 @@ is_installed() {
 }
 
 version() {
-    # basename "$(readlink $(brew --prefix $SETUP_CURRENT_ROLE_NAME 2>/dev/null))"
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/bash)"
 }
 
 config() {

--- a/roles/bats-core/setup.sh
+++ b/roles/bats-core/setup.sh
@@ -13,8 +13,7 @@ is_installed() {
 }
 
 version() {
-    # basename "$(readlink $(brew --prefix $SETUP_CURRENT_ROLE_NAME 2>/dev/null))"
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/bats-core)"
 }
 
 config() {

--- a/roles/binutils/setup.sh
+++ b/roles/binutils/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/binutils)"
 }
 
 config() {

--- a/roles/brew/setup.sh
+++ b/roles/brew/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    "$SETUP_CURRENT_ROLE_NAME" --version | sed "s/Homebrew //"
+    brew --version | sed "s/Homebrew //"
 }
 
 config() {

--- a/roles/clipy/setup.sh
+++ b/roles/clipy/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    ls "/usr/local/Caskroom/$SETUP_CURRENT_ROLE_NAME" 2>/dev/null
+    ls /usr/local/Caskroom/clipy 2>/dev/null
 }
 
 config() {

--- a/roles/coreutils/setup.sh
+++ b/roles/coreutils/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/coreutils)"
 }
 
 config() {

--- a/roles/ctags/setup.sh
+++ b/roles/ctags/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/ctags)"
 }
 
 config() {

--- a/roles/curl/setup.sh
+++ b/roles/curl/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/curl)"
 }
 
 config() {

--- a/roles/dep/setup.sh
+++ b/roles/dep/setup.sh
@@ -13,8 +13,7 @@ is_installed() {
 }
 
 version() {
-    # basename "$(readlink $(brew --prefix $SETUP_CURRENT_ROLE_NAME 2>/dev/null))"
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/dep)"
 }
 
 config() {

--- a/roles/diffutils/setup.sh
+++ b/roles/diffutils/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/diffutils)"
 }
 
 config() {

--- a/roles/direnv/setup.sh
+++ b/roles/direnv/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/direnv)"
 }
 
 config() {

--- a/roles/docker/setup.sh
+++ b/roles/docker/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    ls "/usr/local/Caskroom/$SETUP_CURRENT_ROLE_NAME" 2>/dev/null
+    ls /usr/local/Caskroom/docker 2>/dev/null
 }
 
 config() {

--- a/roles/dropbox/setup.sh
+++ b/roles/dropbox/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    ls "/usr/local/Caskroom/$SETUP_CURRENT_ROLE_NAME" 2>/dev/null
+    ls /usr/local/Caskroom/dropbox 2>/dev/null
 }
 
 config() {

--- a/roles/ed/setup.sh
+++ b/roles/ed/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/ed)"
 }
 
 config() {

--- a/roles/findutils/setup.sh
+++ b/roles/findutils/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/findutils)"
 }
 
 config() {

--- a/roles/flake8/setup.sh
+++ b/roles/flake8/setup.sh
@@ -20,7 +20,7 @@ is_installed() {
 }
 
 version() {
-    pip show "$SETUP_CURRENT_ROLE_NAME" | grep 'Version' | sed "s/Version: //"
+    pip show flake8 | grep 'Version' | sed "s/Version: //"
 }
 
 config() {

--- a/roles/fzf/setup.sh
+++ b/roles/fzf/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/fzf)"
 }
 
 config() {

--- a/roles/gawk/setup.sh
+++ b/roles/gawk/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/gawk)"
 }
 
 config() {

--- a/roles/ghq/setup.sh
+++ b/roles/ghq/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/ghq)"
 }
 
 config() {

--- a/roles/gibo/setup.sh
+++ b/roles/gibo/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/gibo)"
 }
 
 config() {

--- a/roles/git-secrets/setup.sh
+++ b/roles/git-secrets/setup.sh
@@ -13,8 +13,7 @@ is_installed() {
 }
 
 version() {
-    # basename "$(readlink $(brew --prefix $SETUP_CURRENT_ROLE_NAME 2>/dev/null))"
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/git-secrets)"
 }
 
 config() {

--- a/roles/git/setup.sh
+++ b/roles/git/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/git)"
 }
 
 config() {

--- a/roles/gnu-getopt/setup.sh
+++ b/roles/gnu-getopt/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/gnu-getopt)"
 }
 
 config() {

--- a/roles/gnu-indent/setup.sh
+++ b/roles/gnu-indent/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/gnu-indent)"
 }
 
 config() {

--- a/roles/gnu-sed/setup.sh
+++ b/roles/gnu-sed/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/gnu-sed)"
 }
 
 config() {

--- a/roles/gnu-tar/setup.sh
+++ b/roles/gnu-tar/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/gnu-tar)"
 }
 
 config() {

--- a/roles/gnu-which/setup.sh
+++ b/roles/gnu-which/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/gnu-which)"
 }
 
 config() {

--- a/roles/go-pry/setup.sh
+++ b/roles/go-pry/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    "$SETUP_CURRENT_ROLE_NAME" --version
+    go-pry --version
 }
 
 config() {

--- a/roles/go/setup.sh
+++ b/roles/go/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/go)"
 }
 
 config() {

--- a/roles/goenv/setup.sh
+++ b/roles/goenv/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/goenv)"
 }
 
 config() {

--- a/roles/google-chrome/setup.sh
+++ b/roles/google-chrome/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    ls "/usr/local/Caskroom/$SETUP_CURRENT_ROLE_NAME" 2>/dev/null
+    ls /usr/local/Caskroom/google-chrome 2>/dev/null
 }
 
 config() {

--- a/roles/google-japanese-ime/setup.sh
+++ b/roles/google-japanese-ime/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    ls "/usr/local/Caskroom/$SETUP_CURRENT_ROLE_NAME" 2>/dev/null
+    ls /usr/local/Caskroom/google-japanese-ime 2>/dev/null
 }
 
 config() {

--- a/roles/gpg/setup.sh
+++ b/roles/gpg/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/gpg)"
 }
 
 config() {

--- a/roles/graphviz/setup.sh
+++ b/roles/graphviz/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/graphviz)"
 }
 
 config() {

--- a/roles/grep/setup.sh
+++ b/roles/grep/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/grep)"
 }
 
 config() {

--- a/roles/gzip/setup.sh
+++ b/roles/gzip/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/gzip)"
 }
 
 config() {

--- a/roles/hammerspoon/setup.sh
+++ b/roles/hammerspoon/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    ls "/usr/local/Caskroom/$SETUP_CURRENT_ROLE_NAME" 2>/dev/null
+    ls /usr/local/Caskroom/hammerspoon 2>/dev/null
 }
 
 config() {

--- a/roles/hub/setup.sh
+++ b/roles/hub/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/hub)"
 }
 
 config() {

--- a/roles/java/setup.sh
+++ b/roles/java/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    ls "/usr/local/Caskroom/$SETUP_CURRENT_ROLE_NAME" 2>/dev/null
+    ls "/usr/local/Caskroom/java" 2>/dev/null
 }
 
 config() {

--- a/roles/jenv/setup.sh
+++ b/roles/jenv/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/jenv)"
 }
 
 config() {

--- a/roles/lua/setup.sh
+++ b/roles/lua/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/lua)"
 }
 
 config() {

--- a/roles/macos-dock/setup.sh
+++ b/roles/macos-dock/setup.sh
@@ -14,7 +14,7 @@ is_installed() {
 }
 
 version() {
-    echo "-"
+    echo "None"
 }
 
 config() {

--- a/roles/macos-sharing/setup.sh
+++ b/roles/macos-sharing/setup.sh
@@ -14,7 +14,7 @@ is_installed() {
 }
 
 version() {
-    echo "-"
+    echo "None"
 }
 
 config() {

--- a/roles/macos-terminal/setup.sh
+++ b/roles/macos-terminal/setup.sh
@@ -14,7 +14,7 @@ is_installed() {
 }
 
 version() { 
-    echo "-"
+    echo "None"
 }
 
 config() {

--- a/roles/macvim/setup.sh
+++ b/roles/macvim/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    ls "/usr/local/Caskroom/$SETUP_CURRENT_ROLE_NAME" 2>/dev/null
+    ls /usr/local/Cellar/macvim 2>/dev/null
 }
 
 config() {

--- a/roles/memo/setup.sh
+++ b/roles/memo/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    "$SETUP_CURRENT_ROLE_NAME" --version
+    memo --version | awk '{print $3}'
 }
 
 config() {

--- a/roles/nodenv/setup.sh
+++ b/roles/nodenv/setup.sh
@@ -17,7 +17,7 @@ _is_installed_node-build() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/nodenv)"
 }
 
 config() {

--- a/roles/npm/setup.sh
+++ b/roles/npm/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/npm)"
 }
 
 config() {

--- a/roles/openssl/setup.sh
+++ b/roles/openssl/setup.sh
@@ -13,8 +13,7 @@ is_installed() {
 }
 
 version() {
-    # basename "$(readlink $(brew --prefix $SETUP_CURRENT_ROLE_NAME 2>/dev/null))"
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/openssl)"
 }
 
 config() {

--- a/roles/pyenv/setup.sh
+++ b/roles/pyenv/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/pyenv)"
 }
 
 config() {

--- a/roles/python/setup.sh
+++ b/roles/python/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/python)"
 }
 
 config() {

--- a/roles/rbenv/setup.sh
+++ b/roles/rbenv/setup.sh
@@ -17,7 +17,7 @@ _is_installed_ruby-build() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/rbenv)"
 }
 
 config() {

--- a/roles/ruby/setup.sh
+++ b/roles/ruby/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/ruby)"
 }
 
 config() {

--- a/roles/skitch/setup.sh
+++ b/roles/skitch/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    ls "/usr/local/Caskroom/$SETUP_CURRENT_ROLE_NAME" 2>/dev/null
+    ls /usr/local/Caskroom/skitch 2>/dev/null
 }
 
 config() {

--- a/roles/the-unarchiver/setup.sh
+++ b/roles/the-unarchiver/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    ls "/usr/local/Caskroom/$SETUP_CURRENT_ROLE_NAME" 2>/dev/null
+    ls /usr/local/Caskroom/the-unarchiver 2>/dev/null
 }
 
 config() {

--- a/roles/tig/setup.sh
+++ b/roles/tig/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/tig)"
 }
 
 config() {

--- a/roles/tmux/setup.sh
+++ b/roles/tmux/setup.sh
@@ -21,7 +21,7 @@ _is_installed_ansifilter() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/tmux)"
 }
 
 config() {

--- a/roles/tree/setup.sh
+++ b/roles/tree/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/tree)"
 }
 
 config() {

--- a/roles/vim/setup.sh
+++ b/roles/vim/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/vim)"
 }
 
 config() {

--- a/roles/watch/setup.sh
+++ b/roles/watch/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/watch)"
 }
 
 config() {

--- a/roles/wget/setup.sh
+++ b/roles/wget/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/wget)"
 }
 
 config() {

--- a/roles/xz/setup.sh
+++ b/roles/xz/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/xz)"
 }
 
 config() {

--- a/roles/zsh/setup.sh
+++ b/roles/zsh/setup.sh
@@ -13,7 +13,7 @@ is_installed() {
 }
 
 version() {
-    basename "$(readlink /usr/local/opt/$SETUP_CURRENT_ROLE_NAME)"
+    basename "$(readlink /usr/local/opt/zsh)"
 }
 
 config() {


### PR DESCRIPTION
## 概要
version 関数をシンプル化

- versions -> version: d1662e4
    - role 全部の version を出力する機能 -> role 単体の version を出力する機能
    - versions 相当のことをしたければ、list 機能と組み合わせればい
        - （※ 細かいエラーハンドリングは別でやる）
- 各ロールの version 関数をシンプル化: 011a626
    - 直接このPRの趣旨にははまらないが、妙に組み込み関数を使うのを止めて、ベタ書きに変更。

<details>
<summary>setup list | awk '{print $1}' | while read line; do echo -n "$line: "; setup version $line; done</summary>

```
$ setup list | awk '{print $1}' \
| while read line; do echo -n "$line: "; setup version $line; done
role: role is not found.
ag: 2.1.0
alfred: 3.6.1_910
awscli:
bash: 4.4.23
bats-core: 1.0.2
binutils: 2.30
brew: 2.2.13
clipy: 1.1.5
coreutils: 8.29
ctags: 5.8_1
curl: 7.60.0
dep: 0.5.1
diffutils: 3.6
direnv: 2.16.0
docker: 18.03.1-ce-mac65_24312
dropbox: latest
ed: 1.14.2
findutils: 4.6.0
flake8:
fzf: 0.17.4
gawk: 4.2.1_1
ghq: 0.8.0
gibo: 1.0.6
git-secrets: 1.2.1
git: 2.20.1
gnu-getopt: 1.1.6
gnu-indent: 2.2.10
gnu-sed: 4.5
gnu-tar: 1.30
gnu-which: 2.21
go-pry: /usr/local/bin/setup: line 184: printf: --: invalid option
printf: usage: printf [-v var] format [arguments]
go: 1.12.1
goenv: 1.14.0
google-chrome: 66.0.3359.181
google-japanese-ime: latest
gpg: 2.2.7
graphviz: 2.40.1
grep: 3.1
gzip: 1.9
hammerspoon: 0.9.66
hub: 2.2.9
java: 10.0.1_10:fb4372174a714e6b8c52526dc134031e
jenv: 0.4.4
lua: 5.3.5
macos-dock: None
macos-sharing: None
macos-terminal: None
macvim: 8.0-146_1
memo: 0.0.4
nodenv: 1.1.2
npm: 13.11.0
openssl: 1.0.2s
pyenv: 1.2.4
python: 3.7.3
rbenv: 1.1.1
ruby: 2.5.1
skitch: 2.8.1
the-unarchiver: 3.11.5_118:1522167978
tig: 2.4.1_1
tmux: 2.7
tree: 1.7.0
vim: 8.1.0250
watch: 3.3.15
wget: 1.19.5
xz: 5.2.4
zsh: 5.5.1
```

</details>
