### PR TITLE
Change list function: to simple

### DIFF
--- a/roles/setup.sh
+++ b/roles/setup.sh
@@ -11,7 +11,7 @@ Command:
     upgrade   [role]...         Upgrade [role]...
     config    [role]...         Configure [role]...
     create    <role>...         Create <role>...
-    check     <role>            Check <role>
+    validate  <role>            Validate <role>
 
 Option:
     --type    <type>            "<type>" specifies "setup.sh.<type>" under _templates directory
@@ -198,7 +198,7 @@ list() {
     done
 }
 
-check() {
+validate() {
     local role="$1"
     local script_path="$SETUP_ROLES_PATH/$role/$DOTF_SETUP_SCRIPT"
     local _install _upgrade _version _readme
@@ -312,7 +312,7 @@ _options() {
         install)    SETUP_FUNC_NAME="install"  ; shift; _parse "$@" ;;
         upgrade)    SETUP_FUNC_NAME="upgrade"  ; shift; _parse "$@" ;;
         config)     SETUP_FUNC_NAME="config"   ; shift; _parse "$@" ;;
-        check)      SETUP_FUNC_NAME="check"    ; shift; _parse "$@" ;;
+        validate)   SETUP_FUNC_NAME="validate" ; shift; _parse "$@" ;;
         *)          usage ;;
     esac
 }
@@ -329,8 +329,8 @@ main() {
     SETUP_ROLES_PATH=$(abs_dirname $0)
     _options "$@"
     case "$SETUP_FUNC_NAME" in
-        check)
-            check ${SETUP_ROLES[@]} ;;
+        validate)
+            validate ${SETUP_ROLES[@]} ;;
         create)
             create ${SETUP_ROLES[@]} ;;
         version) 

--- a/roles/setup.sh
+++ b/roles/setup.sh
@@ -11,6 +11,7 @@ Command:
     upgrade   [role]...         Upgrade [role]...
     config    [role]...         Configure [role]...
     create    <role>...         Create <role>...
+    check     <role>            Check <role>
 
 Option:
     --type    <type>            "<type>" specifies "setup.sh.<type>" under _templates directory
@@ -222,6 +223,33 @@ list() {
     done
 }
 
+check() {
+    local role="$1"
+    local script_path="$SETUP_ROLES_PATH/$role/$DOTF_SETUP_SCRIPT"
+    local _install _upgrade _version _readme
+
+    if [ -e "$script_path" ]; then
+        source "$script_path"
+
+        _readme=$([[ -f "$SETUP_ROLES_PATH/$role/README.md" ]] && echo "$SETUP_TRUE_MARK" || echo "$SETUP_FALSE_MARK")
+        [[ $(type -t install) == "function" ]] && _install="$SETUP_TRUE_MARK" || _install="$SETUP_FALSE_MARK"
+        [[ $(type -t upgrade) == "function" ]] && _upgrade="$SETUP_TRUE_MARK" || _upgrade="$SETUP_FALSE_MARK"
+        [[ $(type -t version) == "function" ]] && _version="$SETUP_TRUE_MARK" || _version="$SETUP_FALSE_MARK"
+
+        printf "README:$_readme "
+        printf "install:$_install "
+        printf "upgrade:$_upgrade "
+        printf "version:$_version "
+        printf "\n"
+
+        unset -f install
+        unset -f upgrade
+        unset -f version
+    else
+        printf "$role is not found.\n"
+    fi
+}
+
 _check() {
     # It checks the implementation status of functions of each role, and terminates processing if not implemented.
     local is_err=0
@@ -309,6 +337,7 @@ _options() {
         install)    SETUP_FUNC_NAME="install"  ; shift; _parse "$@" ;;
         upgrade)    SETUP_FUNC_NAME="upgrade"  ; shift; _parse "$@" ;;
         config)     SETUP_FUNC_NAME="config"   ; shift; _parse "$@" ;;
+        check)      SETUP_FUNC_NAME="check"    ; shift; _parse "$@" ;;
         *)          usage ;;
     esac
 }
@@ -325,6 +354,8 @@ main() {
     SETUP_ROLES_PATH=$(abs_dirname $0)
     _options "$@"
     case "$SETUP_FUNC_NAME" in
+        check)
+            check ${SETUP_ROLES[@]} ;;
         create)
             create ${SETUP_ROLES[@]} ;;
         version) 


### PR DESCRIPTION
##  概要
- list 機能をシンプル化: check 結果は、check コマンドに集約することに。
- list 機能は、role の name だけ出力するだけにした。
- check コマンドを新たに追加した。



## 使用例）全 role のバージョンを表示する
```
$ setup list | while read line; do echo -n "$line: "; setup version $line; done
pyenv: 1.2.4
tig: 2.4.1_1
roles: roles is not found.
vim: 8.1.0250
tree: 1.7.0
coreutils: 8.29
gnu-indent: 2.2.10
wget: 1.19.5
ctags: 5.8_1
google-chrome: 66.0.3359.181
...
```
