### PR TITLE
Delete caveats function

### DIFF
--- a/roles/hammerspoon/setup.sh
+++ b/roles/hammerspoon/setup.sh
@@ -32,7 +32,7 @@ install() {
         brew cask install hammerspoon 
     }
     _config
-    caveats "WARN" "- hammerspoon: Manual Operation -> Launch Hammerspoon > Enable Accessibility"
+    log "WARN" "- hammerspoon: Manual Operation -> Launch Hammerspoon > Enable Accessibility"
 }
 
 upgrade() {

--- a/roles/setup.sh
+++ b/roles/setup.sh
@@ -82,32 +82,6 @@ log() {
     esac
 }
 
-caveats() {
-    # Examples: caveats "INFO" "info message"
-    # It will be displayed at the end after installation
-    local type="${1:?Error: type is required}"
-    local msg="${2:?Error: msg is required}"
-    local caveats
-
-    case "$type" in
-        INFO)   echo "info"; caveats="\e[34m$msg\e[m\n" ;;
-        WARN)   echo "warn"; caveats="\e[35m$msg\e[m\n" ;;
-        ERROR)  echo "error"; caveats="\e[31m$msg\e[m\n" ;;
-        *)      printf "\e[31mFatal: \"$type\" is an undefined type. Please implement it in the \"log\" function.\e[m\n"
-                exit 1
-                ;;
-    esac
-
-    SETUP_CAVEATS_MSGS=("${SETUP_CAVEATS_MSGS[@]}" "$caveats")
-}
-
-_print_caveats() {
-    [[ ${#SETUP_CAVEATS_MSGS[@]} -gt 0 ]] && log "WARN" "\nCaveats:"
-    for ((i = 0; i < ${#SETUP_CAVEATS_MSGS[@]}; i++)) {
-        printf "${SETUP_CAVEATS_MSGS[i]}"
-    }
-}
-
 depend() {
     # This function is called inside main.sh of each role (e.g. depend install brew).
     local func="${1:?Error \"func\" is required}"
@@ -312,16 +286,12 @@ main() {
             list ${SETUP_ROLES[@]} ;;
         install) install ${SETUP_ROLES[@]} ;;
         upgrade) 
-            declare -a SETUP_CAVEATS_MSGS=()
             upgrade ${SETUP_ROLES[@]} 
-            _print_caveats
             ;;
 
         *) # [install|upgrade|config]
-            declare -a SETUP_CAVEATS_MSGS=()
 #            sudov
             execute ${SETUP_ROLES[@]}
-            _print_caveats
             ;;
     esac
 }


### PR DESCRIPTION
## 概要
- caveats function を削除する。
- 代わりに、log function を使う。
- この２つの違いは、出力タイミングの違いだった。
    - caveats: 最後に出る。log: その時に出る。
- ただ、caveats 使ってるのは以下だけだったので影響も少ないし削除することに。
- さらに、 #20 で、サブシェルで execute を呼び出すように変更したので（そっちのほうが簡単）、この機能はそもそも使えなくなった。
    - Ref. https://github.com/humangas/dotfiles/pull/20/commits/0686ad11e0478cd8ef88e15038197865e8c45b17#diff-695af92d81f41a890419503657ddfb3cR137

```
$ ag "caveats"
roles/hammerspoon/setup.sh
35:    caveats "WARN" "- hammerspoon: Manual Operation -> Launch Hammerspoon > Enable Accessibility"
```
